### PR TITLE
Enhancement: WYSIWIG glossary descriptions

### DIFF
--- a/src/Model/GlossaryTerm.php
+++ b/src/Model/GlossaryTerm.php
@@ -3,6 +3,7 @@
 namespace TheSceneman\SilverStripeGlossary\Model;
 
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
@@ -17,7 +18,7 @@ class GlossaryTerm extends DataObject
 
     private static array $db = [
         'Title' => 'Varchar',
-        'Definition' => 'Varchar',
+        'Definition' => 'HTMLText',
     ];
 
     private static array $extensions = [
@@ -37,7 +38,7 @@ class GlossaryTerm extends DataObject
 
         $fields->removeByName('Definition');
 
-        $fields->addFieldsToTab('Root.Main', [TextareaField::create('Definition')]);
+        $fields->addFieldsToTab('Root.Main', [HTMLEditorField::create('Definition')]);
 
         return $fields;
     }

--- a/src/View/GlossaryShortcodeProvider.php
+++ b/src/View/GlossaryShortcodeProvider.php
@@ -2,6 +2,7 @@
 
 namespace TheSceneman\SilverStripeGlossary\View;
 
+use SilverStripe\View\Parsers\ShortcodeParser;
 use TheSceneman\SilverStripeGlossary\Model\GlossaryTerm;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
@@ -43,6 +44,9 @@ class GlossaryShortcodeProvider implements ShortcodeHandler
         if (!$termDefinition) {
             return '';
         }
+
+        // Ensure any shortcodes, such as internal links, are parsed
+        $termDefinition = ShortcodeParser::get_active()->parse($termDefinition);
 
         $data = [
             'Content' => DBField::create_field('HTMLFragment', $content),

--- a/src/View/GlossaryShortcodeProvider.php
+++ b/src/View/GlossaryShortcodeProvider.php
@@ -4,6 +4,7 @@ namespace TheSceneman\SilverStripeGlossary\View;
 
 use TheSceneman\SilverStripeGlossary\Model\GlossaryTerm;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\Parsers\ShortcodeHandler;
 
@@ -31,15 +32,21 @@ class GlossaryShortcodeProvider implements ShortcodeHandler
         }
 
         $termID = $arguments['id'];
-        $termDefinition = GlossaryTerm::get()->byID($termID)->Definition;
+        $glossaryTerm = GlossaryTerm::get()->byID($termID);
 
+        // There's nothing to stop this term from being deleted, so first check that it still exists
+        if (!$glossaryTerm) {
+            return '';
+        }
+
+        $termDefinition = $glossaryTerm->Definition;
         if (!$termDefinition) {
             return '';
         }
 
         $data = [
             'Content' => DBField::create_field('HTMLFragment', $content),
-            'Terminology' => $termDefinition,
+            'Terminology' => DBHTMLText::create()->setValue($termDefinition),
         ];
 
         return ArrayData::create($data)->renderWith(self::class)->forTemplate();


### PR DESCRIPTION
This pull request changes the Glossary Term field from a simple Varchar field to an HTMLText field. This allows for markup to be included within the glossary lookup.