### PR TITLE
Upgrade to support silverstripe 5

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -11,7 +11,7 @@ ShortcodeParser::get('default')
 
 // We should remove the "Glossary" button from the WYSIWYG field for Glossary Term Definition
 $restrictedConfig = clone HTMLEditorConfig::get('cms');
-HTMLEditorConfig::set_config('restricted', $restrictedConfig);
+HTMLEditorConfig::set_config('glossary', $restrictedConfig);
 
 // Add glossary button to WYSIWYG
 $editorConfig = HTMLEditorConfig::get('cms');

--- a/_config.php
+++ b/_config.php
@@ -9,6 +9,10 @@ use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 ShortcodeParser::get('default')
     ->register('glossary_term', [GlossaryShortcodeProvider::class, 'handle_shortcode']);
 
+// We should remove the "Glossary" button from the WYSIWYG field for Glossary Term Definition
+$restrictedConfig = clone HTMLEditorConfig::get('cms');
+HTMLEditorConfig::set_config('restricted', $restrictedConfig);
+
 // Add glossary button to WYSIWYG
 $editorConfig = HTMLEditorConfig::get('cms');
 $editorConfig->enablePlugins([

--- a/_config/glossary.yml
+++ b/_config/glossary.yml
@@ -1,5 +1,5 @@
 ---
-Name: app_glossary
+Name: glossary
 ---
 SilverStripe\Control\Director:
   rules:

--- a/client/dist/js/glossary.js
+++ b/client/dist/js/glossary.js
@@ -207,13 +207,14 @@ const sanitiseShortCodeProperties = (rawProperties) => {
       onSubmit(dialogApi) {
         const termID = dialogApi.getData().glossary;
         // The selected text to be inserted a terminology
-        const selectedText = editor.selection.getNode().innerText;
+        const selectedText = editor.selection.getContent();
         // No text was selected
         if (!selectedText) {
-          return;
+          editor.windowManager.close();
         }
         const newText = `<span data-shortcode="glossary_term" data-id="${termID}">${selectedText}</span>`;
         editor.insertContent(newText);
+        editor.windowManager.close();
       },
     });
   };
@@ -227,7 +228,7 @@ const sanitiseShortCodeProperties = (rawProperties) => {
     editor.ui.registry.addButton("ssglossary", {
       tooltip: "Insert terminology",
       text: "Glossary",
-      onAction: function () {
+      onAction() {
         editor.execCommand("ssglossary");
       },
     });
@@ -254,14 +255,14 @@ const sanitiseShortCodeProperties = (rawProperties) => {
     });
 
     /**
-     * SaveContent event handler. It fires after contents have been saved from the editor
+     * PostProcess event handler. It fires after contents have been saved from the editor
      * We want to save the content with inserted glossary term to db in the format of Shortcodes for further process
      * so we transform the
      * '<span data-shortcode="glossary_term" data-id="1">public cloud</span>' to
      * '[glossary_term id="1"]public cloud[/glossary_term]'
      * See more about Shortcodes here: https://docs.silverstripe.org/en/4/developer_guides/extending/shortcodes/
      */
-    editor.on("SaveContent", (o) => {
+    editor.on("PostProcess", (o) => {
       const parser = new DOMParser();
       const content = parser.parseFromString(o.content, "text/html");
       const filter = `span[data-shortcode="glossary_term"]`;

--- a/client/dist/js/glossary.js
+++ b/client/dist/js/glossary.js
@@ -203,7 +203,7 @@ const sanitiseShortCodeProperties = (rawProperties) => {
       ],
       // Submit event handler. It will be triggered when the 'OK' button is clicked.
       // It gets the selected terminology id and insert it to the selected text in the format of the example code:
-      // <span data-shortcode="glossary_term" data-id="1">public cloud</span>
+      // <strong data-shortcode="glossary_term" data-id="1">public cloud</strong>
       onSubmit(dialogApi) {
         const termID = dialogApi.getData().glossary;
         // The selected text to be inserted a terminology
@@ -212,7 +212,7 @@ const sanitiseShortCodeProperties = (rawProperties) => {
         if (!selectedText) {
           editor.windowManager.close();
         }
-        const newText = `<span data-shortcode="glossary_term" data-id="${termID}">${selectedText}</span>`;
+        const newText = `<strong data-shortcode="glossary_term" data-id="${termID}">${selectedText}</strong>`;
         editor.insertContent(newText);
         editor.windowManager.close();
       },
@@ -258,14 +258,14 @@ const sanitiseShortCodeProperties = (rawProperties) => {
      * PostProcess event handler. It fires after contents have been saved from the editor
      * We want to save the content with inserted glossary term to db in the format of Shortcodes for further process
      * so we transform the
-     * '<span data-shortcode="glossary_term" data-id="1">public cloud</span>' to
+     * '<strong data-shortcode="glossary_term" data-id="1">public cloud</strong>' to
      * '[glossary_term id="1"]public cloud[/glossary_term]'
      * See more about Shortcodes here: https://docs.silverstripe.org/en/4/developer_guides/extending/shortcodes/
      */
     editor.on("PostProcess", (o) => {
       const parser = new DOMParser();
       const content = parser.parseFromString(o.content, "text/html");
-      const filter = `span[data-shortcode="glossary_term"]`;
+      const filter = `strong[data-shortcode="glossary_term"]`;
       const elementList = content.querySelectorAll(filter);
 
       if (elementList.length === 0) {
@@ -304,11 +304,11 @@ const sanitiseShortCodeProperties = (rawProperties) => {
       let {content} = o;
       // Match [glossary_term] shortcodes
       let match = shortCodeParser.match('glossary_term', true, content);
-      // Transform the shortcodes to html '<span>...</span>'
+      // Transform the shortcodes to html '<strong>...</strong>'
       while (match) {
         const { original, properties } = match;
         // Transform the shortcode to raw html
-        const raw = `<span data-shortcode="glossary_term" data-id="${properties.id}">${match.content}</span>`;
+        const raw = `<strong data-shortcode="glossary_term" data-id="${properties.id}">${match.content}</strong>`;
         content = content.replace(original, raw);
         match = shortCodeParser.match('glossary_term', true, content);
       }

--- a/client/dist/js/glossary.js
+++ b/client/dist/js/glossary.js
@@ -176,6 +176,9 @@ const sanitiseShortCodeProperties = (rawProperties) => {
    * @param data The glossary data
    */
   const glossaryModal = (editor, data) => {
+    const [firstItem, ...rest] = data;
+    const currentNode = editor?.selection.getNode();
+    const currentValue = currentNode?.dataset.id ?? firstItem.value;
     editor.windowManager.open({
       title: "Glossary",
       size: 'normal',
@@ -189,7 +192,10 @@ const sanitiseShortCodeProperties = (rawProperties) => {
             label: "Glossary",
             items: data,
           },
-        ]
+        ],
+      },
+      initialData: {
+        glossary: currentValue,
       },
       buttons: [
         {
@@ -210,6 +216,11 @@ const sanitiseShortCodeProperties = (rawProperties) => {
         const selectedText = editor.selection.getContent();
         // No text was selected
         if (!selectedText) {
+          // update value if we're on an allready valid node
+          const currentNode = editor.selection.getNode();
+          if (currentNode && currentNode?.dataset?.shortcode === 'glossary_term') {
+            currentNode.dataset.id = termID;
+          }
           editor.windowManager.close();
         }
         const newText = `<strong data-shortcode="glossary_term" data-id="${termID}">${selectedText}</strong>`;

--- a/client/dist/js/glossary.js
+++ b/client/dist/js/glossary.js
@@ -178,25 +178,36 @@ const sanitiseShortCodeProperties = (rawProperties) => {
   const glossaryModal = (editor, data) => {
     editor.windowManager.open({
       title: "Glossary",
-      width: 330,
-      height: 70,
+      size: 'normal',
       // Add a listbox(dropdown list) to the modal, it enables us to select a terminology
-      body:
-        [
+      body: {
+        type: 'panel',
+        items: [
           {
             type: "listbox",
             name: "glossary",
             label: "Glossary",
-            values: data,
+            items: data,
           },
-        ],
+        ]
+      },
+      buttons: [
+        {
+          type: 'submit',
+          text: 'OK'
+        },
+        {
+          type: 'cancel',
+          text: 'Cancel'
+        }
+      ],
       // Submit event handler. It will be triggered when the 'OK' button is clicked.
       // It gets the selected terminology id and insert it to the selected text in the format of the example code:
       // <span data-shortcode="glossary_term" data-id="1">public cloud</span>
-      onSubmit(v) {
-        const termID = v.data.glossary;
+      onSubmit(dialogApi) {
+        const termID = dialogApi.getData().glossary;
         // The selected text to be inserted a terminology
-        const selectedText = editor.selection.getContent();
+        const selectedText = editor.selection.getNode().innerText;
         // No text was selected
         if (!selectedText) {
           return;
@@ -213,10 +224,12 @@ const sanitiseShortCodeProperties = (rawProperties) => {
    */
   const ssglossary = (editor) => {
     // Add the plugin button to WYSIWYG field
-    editor.addButton("ssglossary", {
+    editor.ui.registry.addButton("ssglossary", {
       tooltip: "Insert terminology",
       text: "Glossary",
-      cmd: "ssglossary",
+      onAction: function () {
+        editor.execCommand("ssglossary");
+      },
     });
 
     // Define the 'ssglossary' command, which will be triggered when the Glossary plugin button is clicked

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/framework": "^4.0",
-        "silverstripe/admin": "^1.0",
-        "symbiote/silverstripe-gridfieldextensions": "^3",
+        "silverstripe/framework": "^5.0",
+        "silverstripe/admin": "^2.0",
+        "symbiote/silverstripe-gridfieldextensions": "^4",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/src/Controllers/GlossaryController.php
+++ b/src/Controllers/GlossaryController.php
@@ -21,7 +21,8 @@ class GlossaryController extends Controller
         foreach (GlossaryTerm::get() as $glossaryTerm) {
             $result[] = [
                 'text' => $glossaryTerm->Title,
-                'value' => $glossaryTerm->ID,
+                // TinyMce requires the value should be string
+                'value' => (string)$glossaryTerm->ID,
             ];
         }
 

--- a/src/Model/GlossaryTerm.php
+++ b/src/Model/GlossaryTerm.php
@@ -3,6 +3,7 @@
 namespace TheSceneman\SilverStripeGlossary\Model;
 
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\ORM\DataObject;
@@ -39,7 +40,12 @@ class GlossaryTerm extends DataObject
         $this->beforeUpdateCMSFields(static function ($fields) use ($self): void {
             $fields->removeByName('Definition');
 
-            $fields->addFieldsToTab('Root.Main', [HTMLEditorField::create('Definition')]);
+            $fields->addFieldsToTab(
+                'Root.Main',
+                [
+                    HTMLEditorField::create('Definition')->setEditorConfig(HTMLEditorConfig::get('restricted'))
+                ]
+            );
         });
 
         $fields = parent::getCMSFields();

--- a/src/Model/GlossaryTerm.php
+++ b/src/Model/GlossaryTerm.php
@@ -44,7 +44,7 @@ class GlossaryTerm extends DataObject
             $fields->addFieldsToTab(
                 'Root.Main',
                 [
-                    HTMLEditorField::create('Definition')->setEditorConfig(HTMLEditorConfig::get('restricted'))
+                    HTMLEditorField::create('Definition')->setEditorConfig(HTMLEditorConfig::get('glossary'))
                 ]
             );
         });

--- a/src/Model/GlossaryTerm.php
+++ b/src/Model/GlossaryTerm.php
@@ -13,6 +13,7 @@ use SilverStripe\Versioned\Versioned;
 /**
  * @property string Title
  * @property string Definition
+ * @mixin Versioned
  */
 class GlossaryTerm extends DataObject
 {
@@ -60,6 +61,7 @@ class GlossaryTerm extends DataObject
 
         $requiredFields = [
             'Title',
+            'Definition',
         ];
 
         $composite->addValidator(RequiredFields::create($requiredFields));

--- a/src/Model/GlossaryTerm.php
+++ b/src/Model/GlossaryTerm.php
@@ -2,10 +2,11 @@
 
 namespace TheSceneman\SilverStripeGlossary\Model;
 
+use SilverStripe\Forms\CompositeValidator;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
-use SilverStripe\Forms\TextareaField;
+use SilverStripe\Forms\RequiredFields;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
@@ -52,4 +53,18 @@ class GlossaryTerm extends DataObject
 
         return $fields;
     }
+
+    public function getCMSCompositeValidator(): CompositeValidator
+    {
+        $composite = parent::getCMSCompositeValidator();
+
+        $requiredFields = [
+            'Title',
+        ];
+
+        $composite->addValidator(RequiredFields::create($requiredFields));
+
+        return $composite;
+    }
+
 }

--- a/src/View/GlossaryShortcodeProvider.php
+++ b/src/View/GlossaryShortcodeProvider.php
@@ -36,13 +36,16 @@ class GlossaryShortcodeProvider implements ShortcodeHandler
         $glossaryTerm = GlossaryTerm::get()->byID($termID);
 
         // There's nothing to stop this term from being deleted, so first check that it still exists
+        // If it doesn't exist, just return the selected content
         if (!$glossaryTerm) {
-            return '';
+            return $content;
         }
 
         $termDefinition = $glossaryTerm->Definition;
+
+        // If there is no definition, just return the selected content
         if (!$termDefinition) {
-            return '';
+            return $content;
         }
 
         // Ensure any shortcodes, such as internal links, are parsed


### PR DESCRIPTION
Make the module compatible with CMS 5. 
Since the TinyMCE has been upgrade from 4 to 6 in CMS5, the feature of glossary module relies on TinyMCE, it is not compatible with CMS 5. So we should upgrade it for supporting CMS5
This PR also includes some small improvements, e.g. if CMS author re-select a word/phrase after a glossary term has been added, the linked term will show up as the default term on the glossary dialog.