### PR TITLE
Add guard clause to the API endpoint

### DIFF
--- a/src/Controllers/GlossaryController.php
+++ b/src/Controllers/GlossaryController.php
@@ -5,6 +5,7 @@ namespace TheSceneman\SilverStripeGlossary\Controllers;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Security\Security;
 use TheSceneman\SilverStripeGlossary\Model\GlossaryTerm;
 
 class GlossaryController extends Controller
@@ -15,6 +16,12 @@ class GlossaryController extends Controller
 
     public function glossary(HTTPRequest $request): HTTPResponse
     {
+        $member = Security::getCurrentUser();
+
+        if ($member === null) {
+            return $this->httpError(403, 'Forbidden');
+        }
+
         $result = [];
 
         /** @var GlossaryTerm $glossaryTerm */

--- a/tests/GlossaryControllerTest.php
+++ b/tests/GlossaryControllerTest.php
@@ -2,21 +2,38 @@
 
 namespace TheSceneman\SilverStripeGlossary\Tests;
 
-use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\FunctionalTest;
-use TheSceneman\SilverStripeGlossary\Controllers\GlossaryController;
+use SilverStripe\Security\Member;
 
 class GlossaryControllerTest extends FunctionalTest
 {
 
     /**
-     * Tests if API call gives status code 200 (OK response)
+     * @inheritDoc
      */
-    public function testGlossary()
-    {
-        $page = $this->get('api/glossary');
+    protected static $fixture_file = '/tests/fixtures/Member.yml';
 
+    /**
+     * Tests that the API returns a 403 status code when the user is not logged in
+     */
+    public function testGlossaryNotLoggedIn(): void
+    {
+        $page = $this->get('api/glossary/');
+
+        $this->assertEquals(403, $page->getStatusCode());
+    }
+
+    /**
+     * Tests that the API will only return the 200 response when the user is a logged in CMS user
+     */
+    public function testGlossaryLoggedIn(): void
+    {
+        $loggedInUser = $this->objFromFixture(Member::class, 'content-author');
+        $this->logInAs($loggedInUser);
+
+        $page = $this->get('api/glossary/');
         $this->assertEquals(200, $page->getStatusCode());
+
     }
 
 }

--- a/tests/GlossaryControllerTest.php
+++ b/tests/GlossaryControllerTest.php
@@ -18,7 +18,7 @@ class GlossaryControllerTest extends FunctionalTest
      */
     public function testGlossaryNotLoggedIn(): void
     {
-        $page = $this->get('api/glossary/');
+        $page = $this->get('glossary-api/glossary/');
 
         $this->assertEquals(403, $page->getStatusCode());
     }
@@ -31,9 +31,8 @@ class GlossaryControllerTest extends FunctionalTest
         $loggedInUser = $this->objFromFixture(Member::class, 'content-author');
         $this->logInAs($loggedInUser);
 
-        $page = $this->get('api/glossary/');
+        $page = $this->get('glossary-api/glossary/');
         $this->assertEquals(200, $page->getStatusCode());
-
     }
 
 }

--- a/tests/fixtures/Member.yml
+++ b/tests/fixtures/Member.yml
@@ -1,0 +1,25 @@
+SilverStripe\Security\Permission:
+  admin:
+    Code: 'ADMIN'
+  cms-access:
+    Code: 'CMS_ACCESS'
+
+SilverStripe\Security\Group:
+  admin:
+    Title: 'Admin'
+    Code: 'admin'
+    Permissions: =>SilverStripe\Security\Permission.admin
+  cms-author:
+    Title: 'CMS authors'
+    Code: 'cms-author'
+    Permissions: =>SilverStripe\Security\Permission.cms-access
+
+SilverStripe\Security\Member:
+  admin:
+    FirstName: 'Admin'
+    Email: 'admin@silverstripe.com'
+    Groups: =>SilverStripe\Security\Group.admin
+  content-author:
+    FirstName: 'Content author'
+    Email: 'content-author@silverstripe.com'
+    Groups: =>SilverStripe\Security\Group.cms-author


### PR DESCRIPTION
This PR adds a defensive guard check in the API endpoint call.

Ideally we should only return results to the CMS authors viewing the glossary terms in the TinyMCE dropdown.

All other calls should return a `403` forbidden response.