### PR TITLE
Remove trailing space from term

### DIFF
--- a/templates/TheSceneman/SilverStripeGlossary/View/GlossaryShortcodeProvider.ss
+++ b/templates/TheSceneman/SilverStripeGlossary/View/GlossaryShortcodeProvider.ss
@@ -1,3 +1,2 @@
 <% require css('thesceneman/silverstripe-glossary:client/dist/styles/bundle.css') %>
-<span tabindex="0" class="inline-glossary-term">$Content <span class="inline-glossary-definition">$Terminology.RAW.Plain</span></span>
-
+<span tabindex="0" class="inline-glossary-term">$Content<span class="inline-glossary-definition">$Terminology.RAW.Plain</span></span>


### PR DESCRIPTION
The template added a trailing space to the term when it was linked. This looked weird when a term was at the end of a sentence, because of the unnecessary space between term and period.