### PR TITLE
DEP: Upgrade to CMS 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/framework": "^5.0",
-        "silverstripe/admin": "^2.0",
-        "symbiote/silverstripe-gridfieldextensions": "^4",
+        "silverstripe/framework": "^6.0",
+        "silverstripe/admin": "^3.0",
+        "symbiote/silverstripe-gridfieldextensions": "^5",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Model/GlossaryTerm.php
+++ b/src/Model/GlossaryTerm.php
@@ -2,11 +2,11 @@
 
 namespace TheSceneman\SilverStripeGlossary\Model;
 
-use SilverStripe\Forms\CompositeValidator;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
-use SilverStripe\Forms\RequiredFields;
+use SilverStripe\Forms\Validation\CompositeValidator;
+use SilverStripe\Forms\Validation\RequiredFieldsValidator;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
@@ -64,7 +64,7 @@ class GlossaryTerm extends DataObject
             'Definition',
         ];
 
-        $composite->addValidator(RequiredFields::create($requiredFields));
+        $composite->addValidator(RequiredFieldsValidator::create($requiredFields));
 
         return $composite;
     }

--- a/src/View/GlossaryShortcodeProvider.php
+++ b/src/View/GlossaryShortcodeProvider.php
@@ -6,7 +6,7 @@ use SilverStripe\View\Parsers\ShortcodeParser;
 use TheSceneman\SilverStripeGlossary\Model\GlossaryTerm;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
-use SilverStripe\View\ArrayData;
+use SilverStripe\Model\ArrayData;
 use SilverStripe\View\Parsers\ShortcodeHandler;
 
 class GlossaryShortcodeProvider implements ShortcodeHandler


### PR DESCRIPTION
This PR upgrades the glossary tooltip module to CMS 6.

Screenshot
<img width="1331" height="697" alt="Screenshot 2025-08-08 at 12 27 51 PM" src="https://github.com/user-attachments/assets/dcb8e72a-e03f-43e7-9b36-e1e47a666ed2" />
